### PR TITLE
[new package] libspelling

### DIFF
--- a/mingw-w64-libspelling/PKGBUILD
+++ b/mingw-w64-libspelling/PKGBUILD
@@ -1,0 +1,53 @@
+# Maintainer: g-willems <136915997+g-willems@users.noreply.github.com>
+
+_realname=libspelling
+pkgbase=mingw-w64-${_realname}
+pkgname="${MINGW_PACKAGE_PREFIX}-${_realname}"
+pkgver=0.2.1
+pkgrel=1
+pkgdesc="A GNOME library for spellchecking (mingw-w64)"
+arch=('any')
+mingw_arch=('mingw64' 'ucrt64' 'clang64' 'clangarm64')
+url="https://gitlab.gnome.org/GNOME/libspelling"
+msys2_repository_url="https://gitlab.gnome.org/GNOME/libspelling"
+license=("spdx:LGPL-2.1-or-later")
+depends=(
+  "${MINGW_PACKAGE_PREFIX}-gtk4"
+  "${MINGW_PACKAGE_PREFIX}-gtksourceview5"
+  "${MINGW_PACKAGE_PREFIX}-icu"
+  "${MINGW_PACKAGE_PREFIX}-enchant"
+  )
+makedepends=(
+  "${MINGW_PACKAGE_PREFIX}-cc"
+  "${MINGW_PACKAGE_PREFIX}-gobject-introspection"
+  "${MINGW_PACKAGE_PREFIX}-meson"
+  "${MINGW_PACKAGE_PREFIX}-pkgconf"
+  "${MINGW_PACKAGE_PREFIX}-vala"
+  )
+source=("https://download.gnome.org/sources/${_realname}/${pkgver%.*}/${_realname}-${pkgver}.tar.xz")
+sha256sums=('7a787b467bd493f6baffb44138dbc4bef78aaab60efb76a7db88b243bf0f6343')
+
+prepare() {
+  cd "${srcdir}/${_realname}-${pkgver}"
+}
+
+build() {
+  mkdir -p ${srcdir}/build-${MSYSTEM} && cd ${srcdir}/build-${MSYSTEM}
+
+  MSYS2_ARG_CONV_EXCL="--prefix=" \
+  ${MINGW_PREFIX}/bin/meson.exe setup \
+    --prefix="${MINGW_PREFIX}" \
+    --buildtype=plain \
+    -Ddocs=false \
+    -Dvapi=true \
+    -Denchant=enabled \
+    "../${_realname}-${pkgver}"
+
+  ${MINGW_PREFIX}/bin/meson.exe compile
+}
+
+package() {
+  ${MINGW_PREFIX}/bin/meson.exe install -C "${srcdir}/build-${MSYSTEM}" --destdir "${pkgdir}"
+
+  install -Dm644 "${srcdir}/${_realname}-${pkgver}/COPYING" "${pkgdir}${MINGW_PREFIX}/share/licenses/${_realname}/COPYING"
+}


### PR DESCRIPTION
## Description

A GNOME library for spellchecking

This is the official gtk4 successor of `gtkspell` (gtk+2) and `gspell` (gtk+3).
